### PR TITLE
WABT 1.0.12

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,57 +1,61 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
+
+name = "WABT"
+version = v"1.0.12"
 
 # Collection of sources required to build WABT
 sources = [
-    "https://github.com/WebAssembly/wabt/archive/1.0.0.tar.gz" =>
-    "a5d4cfb410fbe94814ed8ae67a2c356c4ea39d26578ca5b48a8d7ede2a0e08eb",
+    "https://github.com/WebAssembly/wabt.git" =>
+    "cf261f2bd561297e0da7008ddde8c09ba5ea35a2",
 
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd wabt-1.0.0/
-if [ $target = "x86_64-w64-mingw32" ] || [ $target = "i686-w64-mingw32" ]; then
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DCMAKE_BUILD_TYPE=gcc-release -DBUILD_TESTS=OFF -DCMAKE_CXX_FLAGS="-static -no-pie" -DCMAKE_C_FLAGS="-static -no-pie"
-else
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DCMAKE_BUILD_TYPE=gcc-release -DBUILD_TESTS=OFF
-fi
-
+cd wabt
+git submodule update --init
+mkdir build 
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ..
 make -j8
 make install
-
-if [ $target = "x86_64-w64-mingw32" ]; then
-  echo hello
-fi
 
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    BinaryProvider.Windows(:x86_64),
-    BinaryProvider.Windows(:i686),
-    BinaryProvider.MacOS(:x86_64, :blank_libc, :blank_abi),
-    BinaryProvider.Linux(:i686, :glibc, :blank_abi),
-    BinaryProvider.Linux(:x86_64, :glibc, :blank_abi),
-    BinaryProvider.Linux(:aarch64, :glibc, :blank_abi),
-    BinaryProvider.Linux(:armv7l, :glibc, :eabihf),
-    BinaryProvider.Linux(:powerpc64le, :glibc, :blank_abi),
-    BinaryProvider.Linux(:i686, :musl, :blank_abi),
-    BinaryProvider.Linux(:x86_64, :musl, :blank_abi),
-    BinaryProvider.Linux(:aarch64, :musl, :blank_abi),
-    BinaryProvider.Linux(:armv7l, :musl, :eabihf)
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64),
+    Windows(:i686),
+    Windows(:x86_64)
 ]
 
 # The products that we will ensure are always built
 products(prefix) = [
-    ExecutableProduct(prefix, "", :wast_sugar),
-    ExecutableProduct(prefix, "", :wasm_objdump),
-    ExecutableProduct(prefix, "", :wasm_interp),
-    ExecutableProduct(prefix, "", :wasm_link),
-    ExecutableProduct(prefix, "", :wasm_opcodecnt),
-    ExecutableProduct(prefix, "", :wast2wasm),
-    ExecutableProduct(prefix, "", :wasm2wast)
+    ExecutableProduct(prefix, "wasm-interp", :wasm_interp),
+    ExecutableProduct(prefix, "wat2wasm", :wat2wasm),
+    ExecutableProduct(prefix, "wasm2c", :wasm2c),
+    ExecutableProduct(prefix, "wast2json", :wast2json),
+    ExecutableProduct(prefix, "wat-desugar", :wat_desugar),
+    ExecutableProduct(prefix, "wasm2wat", :wasm2wat),
+    ExecutableProduct(prefix, "wasm-validate", :wasm_validate),
+    ExecutableProduct(prefix, "wasm-opcodecnt", :wasm_opcodecnt),
+    ExecutableProduct(prefix, "wasm-objdump", :wasm_objdump),
+    ExecutableProduct(prefix, "wasm-strip", :wasm_strip),
+    ExecutableProduct(prefix, "spectest-interp", :spectest_interp)
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -60,5 +64,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, "WABT", sources, script, platforms, products, dependencies)
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
There have been quite a few naming and syntax changes since this repo was last updated. This updates the build script for modern BinaryBuilder, and provides the latest version of WABT.